### PR TITLE
cmd/segment-reaper: add support for >65 segments

### DIFF
--- a/cmd/segment-reaper/bitmask_test.go
+++ b/cmd/segment-reaper/bitmask_test.go
@@ -18,20 +18,20 @@ func TestBitmask(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			var (
 				expectedIdx = rand.Intn(64)
-				mask        bitmask
+				bits        bitArray
 			)
 
-			err := mask.Set(expectedIdx)
+			err := bits.Set(expectedIdx)
 			require.NoError(t, err)
 		})
 
 		t.Run("error: negative index", func(t *testing.T) {
 			var (
 				invalidIdx = -(rand.Intn(math.MaxInt32-1) + 1)
-				mask       bitmask
+				bits       bitArray
 			)
 
-			err := mask.Set(invalidIdx)
+			err := bits.Set(invalidIdx)
 			assert.Error(t, err)
 			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
 		})
@@ -39,12 +39,12 @@ func TestBitmask(t *testing.T) {
 		t.Run("error: index > 63", func(t *testing.T) {
 			var (
 				invalidIdx = rand.Intn(math.MaxInt16) + 64
-				mask       bitmask
+				bits       bitArray
 			)
 
-			err := mask.Set(invalidIdx)
-			assert.Error(t, err)
-			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
+			err := bits.Set(invalidIdx)
+			assert.NoError(t, err)
+			assert.False(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
 		})
 	})
 
@@ -52,10 +52,10 @@ func TestBitmask(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
 			var (
 				expectedIdx = rand.Intn(64)
-				mask        bitmask
+				bits        bitArray
 			)
 
-			has, err := mask.Has(expectedIdx)
+			has, err := bits.Has(expectedIdx)
 			require.NoError(t, err)
 			assert.False(t, has)
 		})
@@ -63,21 +63,10 @@ func TestBitmask(t *testing.T) {
 		t.Run("error: negative index", func(t *testing.T) {
 			var (
 				invalidIdx = -(rand.Intn(math.MaxInt32-1) + 1)
-				mask       bitmask
+				bits       bitArray
 			)
 
-			_, err := mask.Has(invalidIdx)
-			assert.Error(t, err)
-			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
-		})
-
-		t.Run("error: index > 63", func(t *testing.T) {
-			var (
-				invalidIdx = rand.Intn(math.MaxInt16) + 64
-				mask       bitmask
-			)
-
-			_, err := mask.Has(invalidIdx)
+			_, err := bits.Has(invalidIdx)
 			assert.Error(t, err)
 			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
 		})
@@ -87,10 +76,10 @@ func TestBitmask(t *testing.T) {
 		t.Run("index not set", func(t *testing.T) {
 			var (
 				expectedIdx = rand.Intn(64)
-				mask        bitmask
+				bits        bitArray
 			)
 
-			has, err := mask.Has(expectedIdx)
+			has, err := bits.Has(expectedIdx)
 			require.NoError(t, err, "Has")
 			assert.False(t, has, "expected tracked index")
 		})
@@ -98,13 +87,13 @@ func TestBitmask(t *testing.T) {
 		t.Run("index is set", func(t *testing.T) {
 			var (
 				expectedIdx = rand.Intn(64)
-				mask        bitmask
+				bits        bitArray
 			)
 
-			err := mask.Set(expectedIdx)
+			err := bits.Set(expectedIdx)
 			require.NoError(t, err, "Set")
 
-			has, err := mask.Has(expectedIdx)
+			has, err := bits.Has(expectedIdx)
 			require.NoError(t, err, "Has")
 			assert.True(t, has, "expected tracked index")
 		})
@@ -113,20 +102,20 @@ func TestBitmask(t *testing.T) {
 			var (
 				expectedIdx = rand.Intn(63)
 				times       = rand.Intn(10) + 2
-				mask        bitmask
+				bits        bitArray
 			)
 
 			for i := 0; i < times; i++ {
-				err := mask.Set(expectedIdx)
+				err := bits.Set(expectedIdx)
 				require.NoError(t, err, "Set")
 			}
 
-			has, err := mask.Has(expectedIdx)
+			has, err := bits.Has(expectedIdx)
 			require.NoError(t, err, "Has")
 			assert.True(t, has, "expected tracked index")
 
 			// Another index isn't set
-			has, err = mask.Has(expectedIdx + 1)
+			has, err = bits.Has(expectedIdx + 1)
 			require.NoError(t, err, "Has")
 			assert.False(t, has, "not expected tracked index")
 		})
@@ -135,19 +124,19 @@ func TestBitmask(t *testing.T) {
 			var (
 				numIndexes = rand.Intn(61) + 2
 				indexes    = make([]int, numIndexes)
-				mask       bitmask
+				bits       bitArray
 			)
 
 			for i := 0; i < numIndexes; i++ {
 				idx := rand.Intn(63)
 				indexes[i] = idx
 
-				err := mask.Set(idx)
+				err := bits.Set(idx)
 				require.NoError(t, err, "Set")
 			}
 
 			for _, idx := range indexes {
-				has, err := mask.Has(idx)
+				has, err := bits.Has(idx)
 				require.NoError(t, err, "Has")
 				assert.True(t, has, "expected tracked index")
 			}
@@ -156,9 +145,9 @@ func TestBitmask(t *testing.T) {
 
 	t.Run("Count", func(t *testing.T) {
 		t.Run("when initialized", func(t *testing.T) {
-			var mask bitmask
+			var bits bitArray
 
-			numIndexes := mask.Count()
+			numIndexes := bits.Count()
 			assert.Zero(t, numIndexes)
 		})
 
@@ -166,13 +155,13 @@ func TestBitmask(t *testing.T) {
 			var (
 				numSetCalls        = rand.Intn(61) + 2
 				expectedNumIndexes = numSetCalls
-				mask               bitmask
+				bits               bitArray
 			)
 
 			for i := 0; i < numSetCalls; i++ {
 				idx := rand.Intn(63)
 
-				ok, err := mask.Has(idx)
+				ok, err := bits.Has(idx)
 				require.NoError(t, err, "Has")
 				if ok {
 					// idx was already set in previous iteration
@@ -180,55 +169,55 @@ func TestBitmask(t *testing.T) {
 					continue
 				}
 
-				err = mask.Set(idx)
+				err = bits.Set(idx)
 				require.NoError(t, err, "Set")
 			}
 
-			numIndexes := mask.Count()
+			numIndexes := bits.Count()
 			assert.Equal(t, expectedNumIndexes, numIndexes)
 		})
 	})
 
 	t.Run("IsSequence", func(t *testing.T) {
 		t.Run("empty", func(t *testing.T) {
-			var mask bitmask
+			var bits bitArray
 
-			ok := mask.IsSequence()
+			ok := bits.IsSequence()
 			assert.True(t, ok)
 		})
 
 		t.Run("sequence started index 0", func(t *testing.T) {
 			var (
 				numIndexes = rand.Intn(61) + 2
-				mask       bitmask
+				bits       bitArray
 			)
 
 			for i := 0; i < numIndexes; i++ {
-				err := mask.Set(i)
+				err := bits.Set(i)
 				require.NoError(t, err, "Set")
 			}
 
-			ok := mask.IsSequence()
+			ok := bits.IsSequence()
 			assert.True(t, ok)
 		})
 
 		t.Run("sequence started other index than 0", func(t *testing.T) {
 			var (
 				startIndex = rand.Intn(62) + 1
-				mask       bitmask
+				bits       bitArray
 			)
 
 			for i := startIndex; i < 64; i++ {
-				err := mask.Set(i)
+				err := bits.Set(i)
 				require.NoError(t, err, "Set")
 			}
 
-			ok := mask.IsSequence()
+			ok := bits.IsSequence()
 			assert.False(t, ok)
 		})
 
 		t.Run("no sequence", func(t *testing.T) {
-			var mask bitmask
+			var bits bitArray
 
 			for { // loop until getting a list of non-sequenced indexes
 				var (
@@ -248,7 +237,7 @@ func TestBitmask(t *testing.T) {
 					if i > 0 && (indexes[i-1]-1) < idx {
 						areSequenced = false
 					}
-					err := mask.Set(idx)
+					err := bits.Set(idx)
 					require.NoError(t, err, "Set")
 				}
 
@@ -257,7 +246,7 @@ func TestBitmask(t *testing.T) {
 				}
 			}
 
-			ok := mask.IsSequence()
+			ok := bits.IsSequence()
 			assert.False(t, ok)
 		})
 
@@ -267,25 +256,25 @@ func TestBitmask(t *testing.T) {
 			var (
 				expectedUnsetIdx = rand.Intn(32)
 				expectedSetIdx   = rand.Intn(32) + 32
-				mask             bitmask
+				bits             bitArray
 			)
 
-			err := mask.Set(expectedUnsetIdx)
+			err := bits.Set(expectedUnsetIdx)
 			require.NoError(t, err)
-			has, err := mask.Has(expectedUnsetIdx)
+			has, err := bits.Has(expectedUnsetIdx)
 			require.NoError(t, err)
 			require.True(t, has)
 
-			err = mask.Set(expectedSetIdx)
+			err = bits.Set(expectedSetIdx)
 			require.NoError(t, err)
 
-			err = mask.Unset(expectedUnsetIdx)
+			err = bits.Unset(expectedUnsetIdx)
 			require.NoError(t, err)
-			has, err = mask.Has(expectedUnsetIdx)
+			has, err = bits.Has(expectedUnsetIdx)
 			require.NoError(t, err)
 			require.False(t, has)
 
-			has, err = mask.Has(expectedSetIdx)
+			has, err = bits.Has(expectedSetIdx)
 			require.NoError(t, err)
 			require.True(t, has)
 		})
@@ -293,21 +282,10 @@ func TestBitmask(t *testing.T) {
 		t.Run("error: negative index", func(t *testing.T) {
 			var (
 				invalidIdx = -(rand.Intn(math.MaxInt32-1) + 1)
-				mask       bitmask
+				bits       bitArray
 			)
 
-			err := mask.Unset(invalidIdx)
-			assert.Error(t, err)
-			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
-		})
-
-		t.Run("error: index > 63", func(t *testing.T) {
-			var (
-				invalidIdx = rand.Intn(math.MaxInt16) + 64
-				mask       bitmask
-			)
-
-			err := mask.Unset(invalidIdx)
+			err := bits.Unset(invalidIdx)
 			assert.Error(t, err)
 			assert.True(t, errorBitmaskInvalidIdx.Has(err), "errorBitmaskInvalidIdx class")
 		})

--- a/cmd/segment-reaper/observer_test.go
+++ b/cmd/segment-reaper/observer_test.go
@@ -40,9 +40,7 @@ func TestObserver_processSegment(t *testing.T) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
 
-		obsvr := &observer{
-			objects: make(bucketsObjects),
-		}
+		obsvr := &observer{objects: make(bucketsObjects)}
 
 		testdata1 := generateTestdataObjects(ctx, t, false, false)
 		// Call processSegment with testadata objects of the first project
@@ -64,33 +62,20 @@ func TestObserver_processSegment(t *testing.T) {
 
 		// Assert that objserver keep track global stats of all the segments which
 		// have received through processSegment calls
-		assert.Equal(t,
-			testdata1.expectedInlineSegments+testdata2.expectedInlineSegments,
-			obsvr.inlineSegments,
-			"inlineSegments",
-		)
-		assert.Equal(t,
-			testdata1.expectedInlineSegments+testdata2.expectedInlineSegments,
-			obsvr.lastInlineSegments,
-			"lastInlineSegments",
-		)
-		assert.Equal(t,
-			testdata1.expectedRemoteSegments+testdata2.expectedRemoteSegments,
-			obsvr.remoteSegments,
-			"remoteSegments",
-		)
+		assert.Equal(t, testdata1.expectedInlineSegments+testdata2.expectedInlineSegments,
+			obsvr.inlineSegments, "inlineSegments")
+		assert.Equal(t, testdata1.expectedInlineSegments+testdata2.expectedInlineSegments,
+			obsvr.lastInlineSegments, "lastInlineSegments")
+		assert.Equal(t, testdata1.expectedRemoteSegments+testdata2.expectedRemoteSegments,
+			obsvr.remoteSegments, "remoteSegments")
 	})
 
 	t.Run("object without last segment", func(t *testing.T) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
 
-		var (
-			testdata = generateTestdataObjects(ctx, t, true, false)
-			obsvr    = &observer{
-				objects: make(bucketsObjects),
-			}
-		)
+		var testdata = generateTestdataObjects(ctx, t, true, false)
+		var obsvr = &observer{objects: make(bucketsObjects)}
 
 		// Call processSegment with the testdata
 		for _, objSeg := range testdata.objSegments {
@@ -112,12 +97,10 @@ func TestObserver_processSegment(t *testing.T) {
 		defer ctx.Cleanup()
 
 		var (
-			bucketName  = "test-bucket"
-			projectID   = testrand.UUID()
-			numSegments = 65
-			obsvr       = observer{
-				objects: make(bucketsObjects),
-			}
+			bucketName               = "test-bucket"
+			projectID                = testrand.UUID()
+			numSegments              = 65
+			obsvr                    = observer{objects: make(bucketsObjects)}
 			objPath, objSegmentsRefs = createNewObjectSegments(
 				ctx, t, numSegments, &projectID, bucketName, false, false,
 			)
@@ -176,7 +159,7 @@ func TestObserver_processSegment(t *testing.T) {
 			if assert.Equal(t, 1, len(obsvr.objects[bucketName]), "objects in object map") {
 				if assert.Contains(t, obsvr.objects[bucketName], objPath, "path in bucket objects map") {
 					obj := obsvr.objects[bucketName][objPath]
-					assert.Equal(t, numSegments, int(obj.expectedNumberOfSegments), "Object.expectedNumSegments")
+					assert.Equal(t, numSegments, obj.expectedNumberOfSegments, "Object.expectedNumSegments")
 					assert.True(t, obj.hasLastSegment, "Object.hasLastSegment")
 					assert.False(t, obj.skip, "Object.skip")
 				}
@@ -242,7 +225,7 @@ func TestObserver_processSegment(t *testing.T) {
 		require.Equal(t, 1, len(obsvr.objects[bucketName]), "objects in object map")
 		require.Contains(t, obsvr.objects[bucketName], objPath, "path in bucket objects map")
 		obj := obsvr.objects[bucketName][objPath]
-		assert.Equal(t, 1, int(obj.expectedNumberOfSegments), "Object.expectedNumSegments")
+		assert.Equal(t, 1, obj.expectedNumberOfSegments, "Object.expectedNumSegments")
 		assert.True(t, obj.hasLastSegment, "Object.hasLastSegment")
 		assert.True(t, obj.skip, "Object.skip")
 
@@ -361,7 +344,7 @@ func TestObserver_processSegment(t *testing.T) {
 		require.Equal(t, 1, len(obsvr.objects[bucketName]), "objects in object map")
 		require.Contains(t, obsvr.objects[bucketName], objPath, "path in bucket objects map")
 		obj := obsvr.objects[bucketName][objPath]
-		assert.Equal(t, 1, int(obj.expectedNumberOfSegments), "Object.expectedNumSegments")
+		assert.Equal(t, 1, obj.expectedNumberOfSegments, "Object.expectedNumSegments")
 		assert.True(t, obj.hasLastSegment, "Object.hasLastSegment")
 		assert.True(t, obj.skip, "Object.skip")
 
@@ -436,13 +419,13 @@ func TestObserver_processSegment(t *testing.T) {
 		require.Equal(t, 2, len(obsvr.objects[bucketName]), "objects in object map")
 		require.Contains(t, obsvr.objects[bucketName], pathObjOutDateRange, "path in bucket objects map")
 		obj := obsvr.objects[bucketName][pathObjOutDateRange]
-		assert.Equal(t, numSegmentsObjOutDateRange, int(obj.expectedNumberOfSegments), "Object.expectedNumSegments")
+		assert.Equal(t, numSegmentsObjOutDateRange, obj.expectedNumberOfSegments, "Object.expectedNumSegments")
 		assert.True(t, obj.hasLastSegment, "Object.hasLastSegment")
 		assert.True(t, obj.skip, "Object.skip")
 
 		require.Contains(t, obsvr.objects[bucketName], pathObjInDateRange, "path in bucket objects map")
 		obj = obsvr.objects[bucketName][pathObjInDateRange]
-		assert.Equal(t, numSegmentsObjInDateRange, int(obj.expectedNumberOfSegments), "Object.expectedNumSegments")
+		assert.Equal(t, numSegmentsObjInDateRange, obj.expectedNumberOfSegments, "Object.expectedNumSegments")
 		assert.True(t, obj.hasLastSegment, "Object.hasLastSegment")
 		assert.False(t, obj.skip, "Object.skip")
 
@@ -639,9 +622,9 @@ func TestObserver_processSegment_single_project(t *testing.T) {
 				expectedParts := strings.Split(ttObject.expected, "_")
 				expectedNumberOfSegments, err := strconv.Atoi(expectedParts[0])
 				require.NoError(t, err)
-				assert.Equal(t, expectedNumberOfSegments, int(object.expectedNumberOfSegments))
+				assert.Equal(t, expectedNumberOfSegments, object.expectedNumberOfSegments)
 
-				expectedSegments := bitmask(0)
+				expectedSegments := bitArray{}
 				for i, char := range expectedParts[1] {
 					if char == '_' {
 						break
@@ -668,7 +651,7 @@ func TestObserver_analyzeProject(t *testing.T) {
 
 	tests := []struct {
 		segments                 string
-		expectedNumberOfSegments byte
+		expectedNumberOfSegments int
 		segmentsAfter            string
 	}{
 		// this visualize which segments will be NOT selected as zombie segments
@@ -703,7 +686,7 @@ func TestObserver_analyzeProject(t *testing.T) {
 		t.Run("case_"+strconv.Itoa(testNum), func(t *testing.T) {
 			bucketObjects := make(bucketsObjects)
 			singleObjectMap := make(map[storj.Path]*object)
-			segments := bitmask(0)
+			segments := bitArray{}
 			for i, char := range tt.segments {
 				if char == '_' {
 					break
@@ -725,7 +708,7 @@ func TestObserver_analyzeProject(t *testing.T) {
 			observer := &observer{
 				objects:       bucketObjects,
 				lastProjectID: testrand.UUID().String(),
-				zombieBuffer:  make([]int, 0, maxNumOfSegments),
+				zombieBuffer:  make([]int, 0),
 			}
 			err := observer.findZombieSegments(object)
 			require.NoError(t, err)
@@ -849,14 +832,14 @@ type testdataObjects struct {
 // When withoutLastSegment is true, there will be objects without last segment,
 // otherwise all of them will have a last segment.
 //
-// When withMoreThanMaxNumSegments is true, there will be objects with more
-// segments than the maxNumOfSegments, otherwise all of them will have less or
+// When withMoreThanOldMaxNumSegments is true, there will be objects with more
+// segments than the oldMaxNumOfSegments, otherwise all of them will have less or
 // equal than it.
 func generateTestdataObjects(
-	ctx context.Context, t *testing.T, withoutLastSegment bool, withMoreThanMaxNumSegments bool,
+	ctx context.Context, t *testing.T, withoutLastSegment bool, withMoreThanOldMaxNumSegments bool,
 ) testdataObjects {
 	t.Helper()
-
+	const oldMaxNumOfSegments = 64
 	var (
 		testdata = testdataObjects{
 			expectedObjects: make(bucketsObjects),
@@ -869,7 +852,7 @@ func generateTestdataObjects(
 		numMaxGeneratedSegments         = 10
 	)
 
-	if withMoreThanMaxNumSegments {
+	if withMoreThanOldMaxNumSegments {
 		numMaxGeneratedSegments = 100
 	}
 
@@ -882,7 +865,7 @@ func generateTestdataObjects(
 			numSegments     = rand.Intn(numMaxGeneratedSegments) + 2
 		)
 
-		if numSegments > (maxNumOfSegments + 1) {
+		if numSegments > (oldMaxNumOfSegments + 1) {
 			withMoreThanMaxNumSegmentsCount++
 		}
 
@@ -890,10 +873,10 @@ func generateTestdataObjects(
 		// the previous iterations have less or equal than maximum number of segments
 		// and this is the last iteration then force that the object crated in this
 		// iteration has more segments than the maximum.
-		if withMoreThanMaxNumSegments &&
+		if withMoreThanOldMaxNumSegments &&
 			withMoreThanMaxNumSegmentsCount == 0 &&
 			i == (numObjs-1) {
-			numSegments += maxNumOfSegments
+			numSegments += oldMaxNumOfSegments
 			withMoreThanMaxNumSegmentsCount++
 		}
 
@@ -907,15 +890,13 @@ func generateTestdataObjects(
 
 		expectedObj := findOrCreate(bucketName, objPath, testdata.expectedObjects)
 
-		// only create segments mask if the number of segments is less or equal than
-		// maxNumOfSegments + 1 because the last segment isn't in the bitmask
-		if numSegments <= (maxNumOfSegments + 1) {
-			// segments mask doesn't contain the last segment, hence we move 1 bit more
-			expectedObj.segments = math.MaxUint64 >> (maxNumOfSegments - numSegments + 1)
-			expectedObj.skip = false
-		} else {
-			expectedObj.skip = true
+		// segments mask doesn't contain the last segment, hence numSegments-1
+		b := make([]byte, ((numSegments-1)+8-1)/8)
+		for x := 0; x < numSegments-1; x++ {
+			bitIndex, byteIndex := x%8, x/8
+			b[byteIndex] |= byte(1) << bitIndex
 		}
+		expectedObj.segments = bitArray(b)
 
 		// If withoutLastSegment is true, then choose random objects without last
 		// segment or	force to remove it from the object generated in the last
@@ -939,7 +920,7 @@ func generateTestdataObjects(
 			}
 
 			if withNumSegments {
-				expectedObj.expectedNumberOfSegments = byte(numSegments)
+				expectedObj.expectedNumberOfSegments = numSegments
 			}
 		}
 


### PR DESCRIPTION
Change the bitmask used by segment reaper to use []byte rather than uint64

This passes tests but I have literally no clue how to integration test this.

Change-Id: I393f4598b27cae6e427da2190dd3109bca721c34


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
