### PR TITLE
satellite/orders: ensure that expired deletion doesn't stall

### DIFF
--- a/satellite/dbcleanup/chore.go
+++ b/satellite/dbcleanup/chore.go
@@ -37,25 +37,22 @@ type Chore struct {
 
 	Serials *sync2.Cycle
 	config  Config
-	options *orders.SerialDeleteOptions
+
+	serialsDeleteOptions orders.SerialDeleteOptions
 }
 
 // NewChore creates new chore for deleting DB entries.
 func NewChore(log *zap.Logger, ordersDB orders.DB, config Config) *Chore {
-	var options *orders.SerialDeleteOptions
-	if config.BatchSize > 0 {
-		options = &orders.SerialDeleteOptions{
-			BatchSize: config.BatchSize,
-		}
-	}
-
 	return &Chore{
 		log:    log,
 		orders: ordersDB,
 
 		Serials: sync2.NewCycle(config.SerialsInterval),
 		config:  config,
-		options: options,
+
+		serialsDeleteOptions: orders.SerialDeleteOptions{
+			BatchSize: config.BatchSize,
+		},
 	}
 }
 
@@ -71,7 +68,7 @@ func (chore *Chore) deleteExpiredSerials(ctx context.Context) (err error) {
 
 	now := time.Now()
 
-	deleted, err := chore.orders.DeleteExpiredSerials(ctx, now, chore.options)
+	deleted, err := chore.orders.DeleteExpiredSerials(ctx, now, chore.serialsDeleteOptions)
 	if err != nil {
 		chore.log.Error("deleting expired serial numbers", zap.Error(err))
 	} else {

--- a/satellite/orders/endpoint.go
+++ b/satellite/orders/endpoint.go
@@ -39,7 +39,7 @@ type DB interface {
 	// UnuseSerialNumber removes pair serial number -> storage node id from database
 	UnuseSerialNumber(ctx context.Context, serialNumber storj.SerialNumber, storageNodeID storj.NodeID) error
 	// DeleteExpiredSerials deletes all expired serials in serial_number, used_serials, and consumed_serials table.
-	DeleteExpiredSerials(ctx context.Context, now time.Time, options *SerialDeleteOptions) (_ int, err error)
+	DeleteExpiredSerials(ctx context.Context, now time.Time, options SerialDeleteOptions) (_ int, err error)
 	// DeleteExpiredConsumedSerials deletes all expired serials in the consumed_serials table.
 	DeleteExpiredConsumedSerials(ctx context.Context, now time.Time) (_ int, err error)
 	// GetBucketIDFromSerialNumber returns the bucket ID associated with the serial number

--- a/satellite/orders/serials_test.go
+++ b/satellite/orders/serials_test.go
@@ -46,7 +46,7 @@ func TestSerialNumbers(t *testing.T) {
 		require.True(t, orders.ErrUsingSerialNumber.Has(err))
 		require.Empty(t, bucketID)
 
-		deleted, err := ordersDB.DeleteExpiredSerials(ctx, time.Now(), nil)
+		deleted, err := ordersDB.DeleteExpiredSerials(ctx, time.Now(), orders.SerialDeleteOptions{})
 		require.NoError(t, err)
 		require.Equal(t, deleted, 1)
 
@@ -66,11 +66,9 @@ func TestDeleteExpiredWithOptions(t *testing.T) {
 		err = ordersDB.CreateSerialInfo(ctx, storj.SerialNumber{2}, []byte("bucketID2"), time.Now())
 		require.NoError(t, err)
 
-		options := &orders.SerialDeleteOptions{
+		deleted, err := ordersDB.DeleteExpiredSerials(ctx, time.Now(), orders.SerialDeleteOptions{
 			BatchSize: 1,
-		}
-
-		deleted, err := ordersDB.DeleteExpiredSerials(ctx, time.Now(), options)
+		})
 		require.NoError(t, err)
 		require.Equal(t, 2, deleted)
 

--- a/satellite/satellitedb/orders.go
+++ b/satellite/satellitedb/orders.go
@@ -59,10 +59,10 @@ func (db *ordersDB) CreateSerialInfo(ctx context.Context, serialNumber storj.Ser
 }
 
 // DeleteExpiredSerials deletes all expired serials in the serial_number table.
-func (db *ordersDB) DeleteExpiredSerials(ctx context.Context, now time.Time, options *orders.SerialDeleteOptions) (_ int, err error) {
+func (db *ordersDB) DeleteExpiredSerials(ctx context.Context, now time.Time, options orders.SerialDeleteOptions) (_ int, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	if db.db.implementation == dbutil.Cockroach && options != nil {
+	if db.db.implementation == dbutil.Cockroach && options.BatchSize > 0 {
 		var deleted int
 
 		for {


### PR DESCRIPTION
Add checks to ensure that when somebody uses empty options, the deletion
doesn't loop infinitely.

Change-Id: I1738fb1e7e1f8efbbb954c491cb6489f7bcdc2db


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
